### PR TITLE
This one will fix #14

### DIFF
--- a/src/main/java/com/google/gerrit/plugins/GitLogInputParser.java
+++ b/src/main/java/com/google/gerrit/plugins/GitLogInputParser.java
@@ -62,6 +62,6 @@ public final class GitLogInputParser {
 
     //if manage to get here then we assume that input line is only one
     //revision and return only "to" values, "from" value is empty in this case
-    return Pair.with(null, argv);
+    return Pair.with(argv, null);
   }
 }

--- a/src/test/java/com/google/gerrit/plugins/GitLogInputParserTest.java
+++ b/src/test/java/com/google/gerrit/plugins/GitLogInputParserTest.java
@@ -27,8 +27,8 @@ public class GitLogInputParserTest {
 
   @Test
   public void SingleValueTest() {
-    Assert.assertEquals(Pair.with(null,"to"),
-        GitLogInputParser.parse("to"));
+    Assert.assertEquals(Pair.with("from",null),
+        GitLogInputParser.parse("from"));
   }
 
   @Test
@@ -51,8 +51,8 @@ public class GitLogInputParserTest {
 
   @Test
   public void TildeControlSymbolsTest2() {
-    Assert.assertEquals(Pair.with(null, "to~6"),
-        GitLogInputParser.parse("to~6"));
+    Assert.assertEquals(Pair.with("from~6", null),
+        GitLogInputParser.parse("from~6"));
   }
 
   @Test
@@ -63,8 +63,8 @@ public class GitLogInputParserTest {
 
   @Test
   public void HatControlSymbolsTest2() {
-    Assert.assertEquals(Pair.with(null, "to^"),
-        GitLogInputParser.parse("to^"));
+    Assert.assertEquals(Pair.with("from^", null),
+        GitLogInputParser.parse("from^"));
   }
 
   @Test


### PR DESCRIPTION
LogCommand was replaced with RevWalk. That leads to the following behaviour changes:
1. In case of range commit1..commit2 and commit1 == commit2 will return commit1 without walking through the tree
2. In case of range commit1..commit2 and commit1 != commit2 will walk trough the tree and return all commits between commit1 and commit2 inclusevly (fix #14)
3. In case of range commit1 will walk through the tree and return all commits below commit1 inclusevly
4. commit1 should be above commit2 because it will walk top down
